### PR TITLE
Fix missing hex prefix for gray 50 color

### DIFF
--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -202,7 +202,7 @@ export default {
           1000: "#3f1536",
         },
         gray: {
-          50: "ffffff",
+          50: "#ffffff",
           100: "#f5f5f5",
           200: "#e6e6e6",
           300: "#d9d9d9",


### PR DESCRIPTION
## Summary
- correct gray 50 color value in `tailwind.config.mjs`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_6843138c20b8832b8dd2f703b5490f3b