### PR TITLE
Add Jest and example test

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,15 @@
+const nextJest = require('next/jest')
+
+const createJestConfig = nextJest({
+  dir: './',
+})
+
+const customJestConfig = {
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+  testEnvironment: 'jest-environment-jsdom',
+}
+
+module.exports = createJestConfig(customJestConfig)

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/extend-expect'

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@vercel/analytics": "^1.5.0",
@@ -30,6 +31,11 @@
     "eslint": "^9",
     "eslint-config-next": "15.1.5",
     "postcss": "^8",
-    "tailwindcss": "^3.4.1"
+    "tailwindcss": "^3.4.1",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/jest-dom": "^6.1.6",
+    "@testing-library/user-event": "^14.5.2",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0"
   }
 }

--- a/src/components/__tests__/HeroSection.test.jsx
+++ b/src/components/__tests__/HeroSection.test.jsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react'
+import Hero from '../HeroSection'
+
+describe('HeroSection', () => {
+  it('renders heading text', () => {
+    render(<Hero />)
+    const heading = screen.getByRole('heading', {
+      name: /hi,.*fikril.*mobile engineer based in bandung/i,
+    })
+    expect(heading).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- add Jest config using `next/jest`
- configure Jest DOM setup
- update `package.json` with testing dependencies and a `test` script
- add example test for `HeroSection`

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6843135c0810832ba60703f8a1eb9b68