### PR TITLE
Add contact form and API route

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ Configure the following variables in `.env.local` (or your production environmen
 - `SPOTIFY_REDIRECT_URI` – OAuth redirect URI configured in your Spotify dashboard.
 - `SPOTIFY_REFRESH_TOKEN` – Refresh token used to fetch currently playing tracks.
 - `GITHUB_TOKEN` – GitHub Personal Access Token for the `/api/githubStats` endpoint.
+- `SMTP_HOST` – SMTP server host used for contact form.
+- `SMTP_PORT` – SMTP server port.
+- `SMTP_USER` – SMTP username for authentication.
+- `SMTP_PASS` – SMTP password for authentication.
+- `CONTACT_TO_EMAIL` – Destination address for contact form submissions.
 
 ## Deployment Notes
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react-github-calendar": "^4.5.5",
     "remark": "^15.0.1",
     "remark-html": "^16.0.1",
+    "nodemailer": "^6.9.4",
     "swiper": "^11.2.1",
     "swr": "^2.3.2",
     "tailwind-hamburgers": "^1.3.5"

--- a/src/app/api/contact/route.js
+++ b/src/app/api/contact/route.js
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import nodemailer from "nodemailer";
+
+export async function POST(req) {
+  try {
+    const { name, email, message } = await req.json();
+
+    const transporter = nodemailer.createTransport({
+      host: process.env.SMTP_HOST,
+      port: parseInt(process.env.SMTP_PORT, 10),
+      auth: {
+        user: process.env.SMTP_USER,
+        pass: process.env.SMTP_PASS,
+      },
+    });
+
+    await transporter.sendMail({
+      from: `${name} <${email}>`,
+      to: process.env.CONTACT_TO_EMAIL,
+      subject: `New Contact Message from ${name}`,
+      text: message,
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error("Contact API error:", err);
+    return NextResponse.json({ error: "Failed to send message" }, { status: 500 });
+  }
+}

--- a/src/app/contact/ContactForm.jsx
+++ b/src/app/contact/ContactForm.jsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useState } from "react";
+
+export default function ContactForm() {
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [message, setMessage] = useState("");
+  const [status, setStatus] = useState(null);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setStatus("loading");
+
+    try {
+      const res = await fetch("/api/contact", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name, email, message }),
+      });
+
+      if (!res.ok) throw new Error("Failed to send");
+
+      setStatus("success");
+      setName("");
+      setEmail("");
+      setMessage("");
+    } catch (err) {
+      console.error(err);
+      setStatus("error");
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="max-w-xl mx-auto space-y-4 p-4">
+      <div>
+        <label className="block text-sm font-medium text-slate-200">Name</label>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+          className="mt-1 block w-full rounded-md bg-slate-800 border border-slate-700 p-2 text-slate-100"
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-slate-200">Email</label>
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          className="mt-1 block w-full rounded-md bg-slate-800 border border-slate-700 p-2 text-slate-100"
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-slate-200">Message</label>
+        <textarea
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          required
+          rows="5"
+          className="mt-1 block w-full rounded-md bg-slate-800 border border-slate-700 p-2 text-slate-100"
+        />
+      </div>
+      <button
+        type="submit"
+        className="px-4 py-2 bg-brand-primary text-slate-900 rounded-md hover:opacity-90"
+        disabled={status === "loading"}
+      >
+        {status === "loading" ? "Sending..." : "Send"}
+      </button>
+      {status === "success" && (
+        <p className="text-green-500">Message sent successfully!</p>
+      )}
+      {status === "error" && (
+        <p className="text-red-500">Something went wrong. Please try again.</p>
+      )}
+    </form>
+  );
+}

--- a/src/app/contact/page.js
+++ b/src/app/contact/page.js
@@ -1,0 +1,20 @@
+import Navbar from "@/components/Navbar";
+import Footer from "@/components/Footer";
+import ContactForm from "./ContactForm";
+
+export const metadata = {
+  title: "Contact | Ahmad Fikril Al Muzakki",
+};
+
+export default function ContactPage() {
+  return (
+    <>
+      <Navbar />
+      <main className="min-h-screen pt-20">
+        <h1 className="text-3xl font-semibold text-center text-slate-200 mb-8">Contact Me</h1>
+        <ContactForm />
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/src/components/HeroSection.jsx
+++ b/src/components/HeroSection.jsx
@@ -74,13 +74,9 @@ export default function Hero() {
           "
           variants={childVariants}
         >
-          <Button
-            onClick={() =>
-              (window.location.href = "mailto:fikrildev@gmail.com")
-            }
-          >
-            Contact Me
-          </Button>
+        <Button onClick={() => (window.location.href = "/contact")}>
+          Contact Me
+        </Button>
         </motion.div>
       </div>
     </motion.section>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -32,13 +32,19 @@ export default function Navbar() {
           >
             Blog
           </Link>
-          <Link
-            href="/about"
-            className="text-slate-100 hover:text-brand-primary"
-          >
-            About
-          </Link>
-        </div>
+        <Link
+          href="/about"
+          className="text-slate-100 hover:text-brand-primary"
+        >
+          About
+        </Link>
+        <Link
+          href="/contact"
+          className="text-slate-100 hover:text-brand-primary"
+        >
+          Contact
+        </Link>
+      </div>
 
         {/* Available Badge (Desktop) */}
         <div className="hidden md:block">
@@ -108,6 +114,13 @@ export default function Navbar() {
           onClick={toggleMenu}
         >
           About
+        </Link>
+        <Link
+          href="/contact"
+          className="block py-2 text-slate-200 hover:text-brand-primary"
+          onClick={toggleMenu}
+        >
+          Contact
         </Link>
       </div>
 


### PR DESCRIPTION
## Summary
- add new `/contact` page with form component
- post contact form data to `/api/contact`
- wire up nodemailer email send
- link to contact page from the navbar and hero section
- document SMTP environment variables
- include nodemailer dependency

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684391ba853c832bb9c9c4af5386745e