### PR TITLE
feat(security): allow spotify domains in CSP and image config

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,6 @@
 const csp = [
   "default-src 'self'",
-  "img-src 'self' data: blob:",
+  "img-src 'self' data: blob: https://*.scdn.co https://*.spotifycdn.com",
   "media-src 'self'",
   "style-src 'self' 'unsafe-inline'",
   "script-src 'self' 'unsafe-inline'",
@@ -10,6 +10,12 @@ const csp = [
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  images: {
+    remotePatterns: [
+      { protocol: "https", hostname: "*.scdn.co" },
+      { protocol: "https", hostname: "*.spotifycdn.com" },
+    ],
+  },
   async headers() {
     return [
       {

--- a/src/components/SelectedWork.tsx
+++ b/src/components/SelectedWork.tsx
@@ -126,7 +126,8 @@ export default function SelectedWork({
                 src={project.thumbnail}
                 alt={`${project.title} screenshot`}
                 fill
-                sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 600px"
+                sizes="(max-width: 768px) 100vw, (max-width: 1200px) 60vw, 900px"
+                quality={100}
                 className="object-cover transition-transform duration-500 group-hover:scale-[1.02]"
                 priority={false}
               />

--- a/src/components/SpotifyNowPlaying.tsx
+++ b/src/components/SpotifyNowPlaying.tsx
@@ -28,17 +28,13 @@ export default function SpotifyNowPlaying() {
         }
 
         if (data && data.item) {
-          // console.log("✅ Track Found:", data.item);
-
+          // API returns a simplified shape from lib/spotify.ts
           setTrack({
             name: data.item.name as string,
-            artist: (data.item.artists as Array<{ name: string }>)
-              .map((artist: { name: string }) => artist.name)
-              .join(", "),
-            albumImage: (data.item.album.images[0].url as string) ?? "",
-            spotifyUrl: data.item.external_urls.spotify as string,
+            artist: data.item.artist as string,
+            albumImage: data.item.albumImage as string,
+            spotifyUrl: data.item.spotifyUrl as string,
           });
-          // Check if the flag exists and update the state accordingly.
           setIsLastPlayed(data.last_played === true);
         } else {
           // console.log("🎵 No track data available.");
@@ -87,7 +83,7 @@ export default function SpotifyNowPlaying() {
                   src={track.albumImage}
                   alt="Album Cover"
                   fill
-                  unoptimized
+                  quality={100}
                   className="object-cover rounded-full animate-spin"
                   style={{ animationDuration: "10s" }}
                 />


### PR DESCRIPTION
- Add Spotify CDN domains to CSP img-src directive
- Configure Next.js remote patterns for Spotify image hosts
- Update image quality and sizing in components
- Simplify Spotify API response handling

## Summary

Describe the change and why it’s needed. Link related issue(s).

## Scope

- [ ] No visual or URL changes (unless noted below)
- [ ] Aligned with migration phase and rules in `docs/engineering-rules.md`

## Screenshots / Media (if UI changes)

## Acceptance Criteria

- [ ] Lint passes (`npm run lint`)
- [ ] Build passes (`npm run build`)
- [ ] For content changes, Preview deployment verified

## Notes

Add context, tradeoffs, and follow-ups.
